### PR TITLE
Polybar alignment fixed

### DIFF
--- a/customiso/airootfs/etc/skel/.config/openbox/autostart
+++ b/customiso/airootfs/etc/skel/.config/openbox/autostart
@@ -1,8 +1,17 @@
+## xfce4-settings daemon
+xfsettingsd &
+
+## Enable power management
+xfce4-power-manager &
+
+## About
+#sleep 4 && /usr/local/bin/about.sh
+
 ## Restore Wallpaper
-exec nitrogen --restore &
+nitrogen --restore &
 
 ## Start Compositing Manager
-exec compton -b &
+exec picom -b &
 
 ## Launch Polybar
 sh ~/.config/polybar/launch.sh
@@ -19,12 +28,3 @@ exec thunar --daemon &
 ## Enable Super Keys For Menu
 ksuperkey -e 'Super_L=Alt_L|F1' &
 ksuperkey -e 'Super_R=Alt_L|F1' &
-
-## xfce4-settings daemon
-xfsettingsd &
-
-## Enable power management
-xfce4-power-manager &
-
-## About
-sleep 4 && /usr/local/bin/about.sh


### PR DESCRIPTION
The execution of the commands has been reversed. Now we run xfce first so that the polybar correctly fits the chosen resolution.
